### PR TITLE
add: browserify-shim to externalize react and react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-react": "^6.0.15",
     "babelify": "^7.2.0",
+    "browserify-shim": "^3.8.13",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-contrib-less": "^1.0.1",
@@ -35,5 +36,20 @@
   "bugs": {
     "url": "https://github.com/Tjorriemorrie/react-smallgrid/issues"
   },
-  "homepage": "https://github.com/Tjorriemorrie/react-smallgrid#readme"
+  "homepage": "https://github.com/Tjorriemorrie/react-smallgrid#readme",
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
+  },
+  "browser": {
+    "react": "./node_modules/react/dist/react.js",
+    "react-dom": "./node_modules/react-dom/dist/react-dom.js",
+    "lodash": "./node_modules/lodash"
+  },
+  "browserify-shim": {
+    "./node_modules/react/dist/react.js": "React",
+    "./node_modules/react-dom/dist/react-dom.js": "ReactDOM",
+    "./node_modules/lodash": "lodash"
+  }
 }

--- a/src/examples/1_BasicMinimal.jsx
+++ b/src/examples/1_BasicMinimal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import SmallGrid from './../../dist/js/smallgrid.js';
+import SmallGrid from './../smallgrid.jsx';
 
 
 class MyComponent extends React.Component {


### PR DESCRIPTION
According to your [question](http://stackoverflow.com/questions/34897744/browserify-cannot-find-npm-module)

Now, it works for me.